### PR TITLE
Allow async onPageLoad callback

### DIFF
--- a/lib/server/ssr_helper.js
+++ b/lib/server/ssr_helper.js
@@ -45,7 +45,7 @@ FastRender._mergeFrData = function(req, queryData) {
 
 FastRender.onPageLoad = function(callback) {
 	InjectData.injectToHead = false
-	onPageLoad(sink => {
+	onPageLoad(async sink => {
 		const frContext = new FastRender._Context(
 			sink.request.cookies.meteor_login_token,
 			{
@@ -53,8 +53,8 @@ FastRender.onPageLoad = function(callback) {
 			}
 		)
 
-		FastRender.frContext.withValue(frContext, function() {
-			callback(sink)
+		await FastRender.frContext.withValue(frContext, async function() {
+			await callback(sink)
 			FastRender._mergeFrData(
 				sink.request,
 				FastRender.frContext.get().getData()

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
 	summary:
 		'Render your app before the DDP connection even comes alive - magic?',
-	version: '3.0.2',
+	version: '3.0.3',
 	git: 'https://github.com/abecks/meteor-fast-render',
 	name: 'staringatlights:fast-render',
 })


### PR DESCRIPTION
If you were to provide an async function for the `onPageLoad` callback, SSR would not work; no html would be returned with the response. This meant that we couldn't use API's like Apollo's `getDataFromTree`.

This PR allows you to provide an async function for the `onPageLoad` callback, which enables something like 

```
FastRender.onPageLoad(async sink => {
    // ... Apollo set up (for example)
    await getDataFromTree(<App />);
    sink.renderIntoElementById('app', renderToString(<App />))
    sink.appendToBody(`
        <script>
            window.__APOLLO_STATE__=${JSON.stringify(client.cache.extract())};
        </script>
  `);
})
```