### PR TITLE
Remove underscore dependency from client

### DIFF
--- a/lib/client/ddp_update.js
+++ b/lib/client/ddp_update.js
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor'
 import { FastRender } from './fast_render'
-import { _ } from 'meteor/underscore'
 import { EJSON } from 'meteor/ejson'
 import { IDTools } from './id_tools'
 
@@ -40,11 +39,11 @@ Meteor.connection._livedata_data = function(msg) {
 				}
 			} else if (pendingStoreUpdates) {
 				var mergedDoc = null
-				var existingDocs = _.filter(pendingStoreUpdates, function(doc) {
+				var existingDocs = pendingStoreUpdates.filter(function(doc) {
 					return doc.id === msg.id
 				})
 
-				_.each(existingDocs, function(cachedMsg) {
+				existingDocs.forEach(function(cachedMsg) {
 					mergedDoc = FastRender._ApplyDDP(mergedDoc, cachedMsg)
 				})
 

--- a/lib/client/fast_render.js
+++ b/lib/client/fast_render.js
@@ -1,6 +1,5 @@
 /* global __fast_render_config */
 import { Meteor } from 'meteor/meteor'
-import { _ } from 'meteor/underscore'
 import { IDTools } from './id_tools'
 import { Accounts } from 'meteor/accounts-base'
 
@@ -59,7 +58,8 @@ FastRender.init = function(payload) {
 	//  yes, this is a minimal mergeBox on the client
 	var allData = {}
 	if (payload) {
-		_.each(payload.collectionData, function(subData, collName) {
+		Object.keys(payload.collectionData).forEach(function(collName) {
+            const subData = payload.collectionData[collName];
 			if (!allData[collName]) {
 				allData[collName] = {}
 			}
@@ -79,8 +79,10 @@ FastRender.init = function(payload) {
 
 	var connection = Meteor.connection
 
-	_.each(allData, function(collData, collName) {
-		_.each(collData, function(item, id) {
+	Object.keys(allData).forEach(function(collName) {
+        const collData = allData[collName];
+		Object.keys(collData).forEach(function(id) {
+            const item = collData[id];
 			id = IDTools.idStringify(item._id)
 			delete item._id
 
@@ -130,7 +132,7 @@ FastRender._AddedToChanged = function(localCopy, added) {
 	added.cleared = []
 	added.fields = added.fields || {}
 
-	_.each(localCopy, function(value, key) {
+	Object.keys(localCopy).forEach(function(key) {
 		if (key !== '_id') {
 			if (typeof added.fields[key] == 'undefined') {
 				added.cleared.push(key)
@@ -140,16 +142,16 @@ FastRender._AddedToChanged = function(localCopy, added) {
 }
 
 FastRender._ApplyDDP = function(existing, message) {
-	var newDoc = !existing ? {} : _.clone(existing)
+	var newDoc = !existing ? {} : Object.assign({}, existing)
 	if (message.msg === 'added') {
-		_.each(message.fields, function(value, key) {
-			newDoc[key] = value
+		Object.keys(message.fields).forEach(function(key) {
+			newDoc[key] = message.fields[key];
 		})
 	} else if (message.msg === 'changed') {
-		_.each(message.fields, function(value, key) {
-			newDoc[key] = value
+		Object.keys(message.fields).forEach(function(key) {
+			newDoc[key] = message.fields[key];
 		})
-		_.each(message.cleared, function(key) {
+		message.cleared.forEach(function(key) {
 			delete newDoc[key]
 		})
 	} else if (message.msg === 'removed') {
@@ -165,37 +167,35 @@ FastRender._DeepExtend = function deepExtend(obj) {
 	var parentRE = /#{\s*?_\s*?}/
 	var slice = Array.prototype.slice
 	var hasOwnProperty = Object.prototype.hasOwnProperty
-
-	_.each(slice.call(arguments, 1), function(source) {
+	slice.call(arguments, 1).forEach(function(source) {
 		for (var prop in source) {
 			if (hasOwnProperty.call(source, prop)) {
 				if (
-					_.isNull(obj[prop]) ||
-					_.isUndefined(obj[prop]) ||
-					_.isFunction(obj[prop]) ||
-					_.isNull(source[prop]) ||
-					_.isDate(source[prop])
+					obj[prop] === null ||
+					obj[prop] === undefined ||
+					typeof obj[prop] === 'function' ||
+					source[prop] === null ||
+					source[prop] instanceof Date
 				) {
 					obj[prop] = source[prop]
-				} else if (_.isString(source[prop]) && parentRE.test(source[prop])) {
-					if (_.isString(obj[prop])) {
+				} else if (typeof source[prop] === 'string' && parentRE.test(source[prop])) {
+					if (typeof obj[prop] === 'string') {
 						obj[prop] = source[prop].replace(parentRE, obj[prop])
 					}
-				} else if (_.isArray(obj[prop]) || _.isArray(source[prop])) {
-					if (!_.isArray(obj[prop]) || !_.isArray(source[prop])) {
+				} else if (obj[prop] instanceof Array || source[prop] instanceof Array) {
+					if (!(obj[prop] instanceof Array) || !(source[prop] instanceof Array)) {
 						throw 'Error: Trying to combine an array with a non-array (' +
 							prop +
 							')'
 					} else {
-						obj[prop] = _.reject(
-							FastRender._DeepExtend(obj[prop], source[prop]),
+						obj[prop] = FastRender._DeepExtend(obj[prop], source[prop]).filter(
 							function(item) {
-								return _.isNull(item)
+								return item !== null
 							}
 						)
 					}
-				} else if (_.isObject(obj[prop]) || _.isObject(source[prop])) {
-					if (!_.isObject(obj[prop]) || !_.isObject(source[prop])) {
+				} else if (typeof obj[prop] === 'object' || typeof source[prop] === 'object') {
+					if (typeof obj[prop] !== 'object' || typeof source[prop] !== 'object') {
 						throw 'Error: Trying to combine an object with a non-object (' +
 							prop +
 							')'

--- a/lib/client/ssr_helper.js
+++ b/lib/client/ssr_helper.js
@@ -1,7 +1,6 @@
 import { FastRender } from 'meteor/staringatlights:fast-render'
 import { InjectData } from 'meteor/staringatlights:inject-data'
 import { onPageLoad } from 'meteor/server-render'
-import { Tracker } from 'meteor/tracker'
 
 FastRender.onPageLoad = function(callback) {
 	FastRender.wait()

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
 	summary:
 		'Render your app before the DDP connection even comes alive - magic?',
-	version: '3.0.8',
+	version: '3.1.0',
 	git: 'https://github.com/abecks/meteor-fast-render',
 	name: 'staringatlights:fast-render',
 })

--- a/package.js
+++ b/package.js
@@ -34,7 +34,7 @@ Package.onUse(function(api) {
 		['server']
 	)
 	api.use(
-		['minimongo', 'underscore', 'deps', 'ejson', 'accounts-base'],
+		['minimongo', 'deps', 'ejson', 'accounts-base'],
 		['client']
 	)
 

--- a/package.js
+++ b/package.js
@@ -34,7 +34,7 @@ Package.onUse(function(api) {
 		['server']
 	)
 	api.use(
-		['minimongo', 'deps', 'ejson', 'accounts-base'],
+		['minimongo', 'ejson', 'accounts-base'],
 		['client']
 	)
 


### PR DESCRIPTION
Similar to https://github.com/abecks/meteor-inject-data/pull/8, this removes the dependency on `underscore` from the client. There were several refactors to be done in the client code, but they were all doable with javascript ES6.

The dependency still exists for the server, though. I suppose I could do the same and refactor those, but the intent of these PRs were to help reduce bundle size on the client.