### PR TITLE
Fix: #33 [Meteor 1.9] Deprecation Warning: OutgoingMessage.prototype._headers

### DIFF
--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -6,7 +6,8 @@ import { InjectData } from 'meteor/staringatlights:inject-data'
 import PublishContext from './publish_context'
 import { IsAppUrl } from './utils'
 import { _ } from 'meteor/underscore'
-import connect from 'connect'
+import cookieParser from 'cookie-parser'
+
 
 FastRender._onAllRoutes = []
 FastRender.frContext = new Meteor.EnvironmentVariable()
@@ -14,7 +15,7 @@ FastRender.frContext = new Meteor.EnvironmentVariable()
 var fastRenderRoutes = Picker.filter(function(req, res) {
 	return IsAppUrl(req)
 })
-fastRenderRoutes.middleware(connect.cookieParser())
+fastRenderRoutes.middleware(cookieParser())
 fastRenderRoutes.middleware(function(req, res, next) {
 	FastRender.handleOnAllRoutes(req, res, next)
 })

--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -8,7 +8,6 @@ import { IsAppUrl } from './utils'
 import { _ } from 'meteor/underscore'
 import cookieParser from 'cookie-parser'
 
-
 FastRender._onAllRoutes = []
 FastRender.frContext = new Meteor.EnvironmentVariable()
 

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 })
 
 Npm.depends({
-	connect: '2.13.0',
+	"cookie-parser": '1.4.4',
 })
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Hello, Andrew @abecks. 

This small fix #33 removing deprecation warning for packages that depended on the `staringatlights:fast-render` package:

* `akryum:vue-ssr`
https://github.com/meteor-vue/vue-meteor
* `communitypackages:react-router-ssr`
https://github.com/Meteor-Community-Packages/react-router-ssr/

Best wishes,
Sergey.